### PR TITLE
Don't stop updating lists on Wunderlist API failures

### DIFF
--- a/fetcher.js
+++ b/fetcher.js
@@ -48,12 +48,12 @@ var Fetcher = function (listID, listFrom, reloadInterval, accessToken, clientID)
       .done(function (tasks) {
         items = tasks.map(task => Object.assign(task, {listFrom}));
         self.broadcastItems();
-        scheduleTimer();
       })
       .fail(function (resp, code) {
         console.error('there was a Wunderlist problem', resp, code);
       });
     });
+    scheduleTimer();
 
 
   };


### PR DESCRIPTION
This fixes a bug where this module stops updating if any error is returned from the Wunderlist API (which has a tendency to return 404 or 500 from time to time). Fixes issue #12 and probably #3 too.